### PR TITLE
`grep`: don't include line numbers by default

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -144,8 +144,8 @@ else
 fi
 
 if is_command_available grep; then
-    # `grep` niceties: ignore case, colored output, show line numbers.
-    alias grep='grep --ignore-case --color=auto --line-number'
+    # `grep` niceties: ignore case, colored output
+    alias grep='grep --ignore-case --color=auto'
 else
     echo "~/.zshrc: grep is not available, can't set alias."
 fi


### PR DESCRIPTION
with this enabled, i saw unexpected behavior when chaining multiple grep commands -- e.g. something like this `cat file.txt | grep -E '...' | grep -v -E '...'` -- since line numbers are now a part of the second grep commands input. going to remove from defaults. if I want to use, can just pass the -n flag manually