### PR TITLE
`tmux`: fix new prompt cursor color

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -140,6 +140,13 @@ bind -n C-o select-pane -t:.+
 bind -n M-o select-pane -t:.-
 bind o display-message "Removed this binding. Use C-o or M-o for pane navigation."
 
+# Prompt cursor config, i.e. the cursor that shows up in tmux command/prompt
+# area, such as when you're renaming a window.
+# These vars were introduced in tmux 3.6 with pretty hideous default settings,
+# so setting here explicitly with my preferred scheme to match rest.
+set -g prompt-cursor-colour '#af8700'
+set -g prompt-cursor-style default
+
 ################################################################################
 # Plugins ######################################################################
 ################################################################################


### PR DESCRIPTION
introduced in [version 3.6](https://raw.githubusercontent.com/tmux/tmux/3.6/CHANGES) with default settings I don't like