### PR TITLE
`zshrc`: add `code` alias to `cd ~/code/`

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -94,6 +94,8 @@ fi
 
 alias x='exit'
 
+alias code='cd "$HOME/code"'
+
 if is_command_available emacs; then
     source $dotfiles_dir/zsh/zshrc_emacs
 else


### PR DESCRIPTION
otherwise, this opens up VScode, which is not what I want