### PR TITLE
fix git delta pager issues

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -5,11 +5,11 @@
 
 [core]
 	editor = emacs
-	# Setting the `git-delta` package [1] to be default pager, since has
-	# some nicer features than less. If it's not installed, log a message
-	# to stdout (`echo ...`) & fallback to using `less`
+	# Setting the `git-delta` package [1] to be default pager, since it has
+	# some nicer features than less. If it's not installed, we fallback to using
+	# `less`, see ./zsh/zshrc_git for details.
 	# [1] https://github.com/dandavison/delta
-	pager = sh -c "delta 2>/dev/null || { echo '~/.gitconfig: delta is not installed, falling back to using less.'; less; }"
+	pager = delta
 	# Global gitignore file
 	excludesFile = ~/.gitignore-global
 
@@ -35,9 +35,11 @@
 
 # config for interactive commands, e.g. `git add -p`, `git stash -p`, etc
 [interactive]
-	# Similar fallback mechanisms as above, except we can't log anything in
-	# `diffFilter`, so can't do a `sh` wrapper with a custom `echo` log.
-	diffFilter = delta --color-only || cat
+	# Like above, setting the `git-delta` package [1] to be default diff filter.
+	# Similarly, if it's not installed, we fallback to using `less`, see
+	# ./zsh/zshrc_git for details.
+	# [1] https://github.com/dandavison/delta
+	diffFilter = delta --color-only
 
 # `git-delta` specific config
 [delta]

--- a/zsh/zshrc_git
+++ b/zsh/zshrc_git
@@ -41,7 +41,20 @@ __git_fetch_bg() {
     # Fetch in background silently, as subshell so it doesn't show in jobs
     (git fetch --quiet &>/dev/null &)
 }
-
 # Run on precmd (before every prompt, like pure does)
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd __git_fetch_bg
+
+# set the pager & diff filter to `less` if delta is not available; see related
+# configuration in ~/.gitconfig.
+if ! is_command_available delta; then
+    export GIT_PAGER=less
+    export GIT_CONFIG_COUNT=1
+    export GIT_CONFIG_KEY_0="interactive.diffFilter"
+    export GIT_CONFIG_VALUE_0="cat"
+    echo "~/.zshrc_git: delta is not available, falling back to using less."
+    echo "Note: this will override the pager & diff filter settings in ~/.gitconfig temporarily for this shell session."
+else
+    unset GIT_PAGER
+    unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+fi

--- a/zsh/zshrc_git
+++ b/zsh/zshrc_git
@@ -55,6 +55,5 @@ if ! is_command_available delta; then
     echo "~/.zshrc_git: delta is not available, falling back to using less."
     echo "Note: this will override the pager & diff filter settings in ~/.gitconfig temporarily for this shell session."
 else
-    unset GIT_PAGER
-    unset GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
+    unset GIT_PAGER GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0
 fi


### PR DESCRIPTION
with the upgrade to new `less` version [1], we had weird behavior (pager was in the middle, & cropped; scrolling up & down had bugs) when using `git-delta` when running `git diff` or `git log`. removing the hacky "fallback" mechanisms in `~/.gitconfig` & instead doing it in `zsh/zshrc_git` seemed to fix the issues. not exactly sure what underlying issue was, but at least things look good now.

[1] https://github.com/Homebrew/homebrew-core/commit/6244f6fb7cbcc3f954e98040867657ec0eb9175d