### PR TITLE
`zshrc`: add `man` wrapper for zsh builtin commands

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -275,6 +275,28 @@ bindkey -M emacs "^Y" yank_from_clipboard
 # highlighted & I press backspace, the entire block is deleted, not just the
 # where the cursor was last at.
 
+man() {
+    local zsh_builtins=(
+        alias autoload bg bindkey break builtin bye cap cd chdir clone command
+        comparguments compcall compctl compdescribe compfiles compgroups compquote
+        comptags comptry compvalues continue declare dirs disable disown echo echotc
+        echoti emulate enable eval exec exit export false fc fg float functions
+        getcap getln getopts hash history integer jobs kill let limit local log
+        logout noglob popd print printf pushd pushln pwd r read readonly rehash
+        return sched set setcap setopt shift source stat suspend test times trap
+        true ttyctl type typeset ulimit umask unalias unfunction unhash unlimit
+        unset unsetopt vared wait whence where which zcompile zformat zftp zle
+        zmodload zparseopts zprof zpty zregexparse zsocket zstyle ztcp
+    )
+
+    if echo " ${zsh_builtins[*]} " | grep -q " $1 "; then
+        echo "Note: '$1' is a zsh builtin, so \`man $1\` may not show proper documentation." >&2
+        echo "Consider running \`man zshbuiltins\` & searching for '$1' instead." >&2
+    fi
+
+    command man "$@"
+}
+
 ################################################################################
 # Machine-specific configurations
 ################################################################################


### PR DESCRIPTION
was confusing to have a generic man page displayed, so this gives me an informative error message