### PR TITLE
`zshrc`: add `~/.local/bin` to `PATH`

### DIFF
--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -297,6 +297,9 @@ man() {
     command man "$@"
 }
 
+# Add ~/.local/bin to PATH for local binaries.
+export PATH="$HOME/.local/bin:$PATH"
+
 ################################################################################
 # Machine-specific configurations
 ################################################################################


### PR DESCRIPTION
motivated by cursor CLI agent installation instructions ([here](https://cursor.com/docs/cli/overview)), but this is probs good to do in general