### PR TITLE
`claude`: remap "background task" action to ctrl+q

### DIFF
--- a/claude/keybindings.json
+++ b/claude/keybindings.json
@@ -97,7 +97,7 @@
     {
       "context": "Task",
       "bindings": {
-        "ctrl+b": "task:background"
+        "ctrl+q": "task:background"
       }
     },
     {


### PR DESCRIPTION
ctrl+b interferes with emacs-style navigation keybindings