### PR TITLE
`claude`: remap ctrl+e to something else

### DIFF
--- a/claude/keybindings.json
+++ b/claude/keybindings.json
@@ -66,7 +66,7 @@
         "tab": "confirm:nextField",
         "space": "confirm:toggle",
         "shift+tab": "confirm:cycleMode",
-        "ctrl+e": "confirm:toggleExplanation"
+        "ctrl+x": "confirm:toggleExplanation"
       }
     },
     {
@@ -81,7 +81,7 @@
     {
       "context": "Transcript",
       "bindings": {
-        "ctrl+e": "transcript:toggleShowAll",
+        "ctrl+s": "transcript:toggleShowAll",
         "escape": "transcript:exit"
       }
     },


### PR DESCRIPTION
this is an emacs-style text navigation keybinding