### PR TITLE
`git config --global commit.verbose true`

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -25,6 +25,7 @@
 
 [commit]
 	gpgsign = true
+	verbose = true
 
 [init]
 	defaultBranch = main


### PR DESCRIPTION
I'm doing this so that I don't have to explicitly pass the `-v` flag when running graphite's `gt create {branch_name}`, but figured it doesn't hurt to enable this for all git commit invocations