### PR TITLE
`emacs`: remove `copilot.el` as submodule; cleanup init file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = dotbot
 	url = https://github.com/anishathalye/dotbot
 	ignore = dirty
-[submodule "copilot.el"]
-	path = copilot.el
-	url = https://github.com/zerolfx/copilot.el
-	ignore = dirty


### PR DESCRIPTION
this started as an effort to remove `copilot.el` as a git submodule, since the support for this package has improved significantly since it was first released in 2022, & initialization can be simplified significantly. in particular, removed the need to manually link node binaries & the language server, since these are included in package now.

edit: forgot to finish thought here, but essentially while this started as a scoped effort to remove `copilot.el`, I ended up refactoring the init file quite a bit to be easier to read & simpler