### PR TITLE
move stuff to `~/.config`

### DIFF
--- a/install.conf.yaml
+++ b/install.conf.yaml
@@ -12,7 +12,7 @@
     # [1] https://github.com/anishathalye/dotbot/blob/master/README.md
 
     ### Only link these files on macOS
-    ~/.alfred:
+    ~/.config/alfred:
       if: "[ `uname` = Darwin ]"
       create: true
       force: true
@@ -22,7 +22,7 @@
       create: true
       force: true
       path: macOS-keyboard-shortcuts/karabiner
-    ~/.rectangle.config.json:
+    ~/.config/rectangle.config.json:
       if: "[ `uname` = Darwin ]"
       path: rectangle.config.json
     # Cursor stuff
@@ -71,9 +71,10 @@
       create: true
       force: true
       path: graphite/aliases
+    ~/.config/p10k.zsh: zsh/p10k.zsh
     ~/.config/tmux-powerline: tmux/tmux-powerline
     # Symlink to this repo itself
-    ~/dotfiles: ""
+    ~/.dotfiles: ""
     ~/.emacs.d/init.el:
       create: true
       path: emacs/init.el
@@ -82,7 +83,6 @@
     ~/.hushlogin: hushlogin
     ~/.lesskey: lesskey
     ~/.npmrc: npmrc
-    ~/.p10k.zsh: zsh/p10k.zsh
     ~/.tidyrc: tidyrc
     ~/.tmux.conf: tmux/tmux.conf
     ~/.zprofile: zsh/zprofile

--- a/zsh/fragments/zshrc_git
+++ b/zsh/fragments/zshrc_git
@@ -15,7 +15,7 @@ alias gdcast='git --no-pager diff --cached --stat'
 # Background git fetch for p10k [1] prompt (similar to pure [2]).
 # Unlike pure prompt, p10k/gitstatus doesn't fetch from remote - it only
 # reads local git state. This means VCS_STATUS_COMMITS_{AHEAD,BEHIND}
-# (see ~/.p10k.zsh) is stale unless we periodically fetch.
+# (see ~/.config/p10k.zsh) is stale unless we periodically fetch.
 #
 # Like pure, this runs on every `precmd` (before each prompt is drawn),
 # with a cooldown to avoid hammering the remote. After fetch completes,

--- a/zsh/p10k.zsh
+++ b/zsh/p10k.zsh
@@ -43,7 +43,7 @@ local baby_blue='152' # converted from hex '#ADD8E6', which is what I used in
   emulate -L zsh -o extended_glob
 
   # Unset all configuration options. This allows you to apply configuration changes without
-  # restarting zsh. Edit ~/.p10k.zsh and type `source ~/.p10k.zsh`.
+  # restarting zsh. Edit ~/.config/p10k.zsh and type `source ~/.config/p10k.zsh`.
   unset -m '(POWERLEVEL9K_*|DEFAULT_USER)~POWERLEVEL9K_GITSTATUS_DIR'
 
   # Zsh >= 5.1 is required.

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -17,7 +17,7 @@ source $dotfiles_dir/zsh/checkers.sh
 # general to support other platforms (e.g. Linux) where p10k might be installed
 # differently.
 __p10k_enabled=false
-if [[ -f ~/.p10k.zsh ]] && [[ -f $(brew --prefix)/share/powerlevel10k/powerlevel10k.zsh-theme ]]; then
+if [[ -f ~/.config/p10k.zsh ]] && [[ -f $(brew --prefix)/share/powerlevel10k/powerlevel10k.zsh-theme ]]; then
     __p10k_enabled=true
 fi
 
@@ -33,8 +33,8 @@ if $__p10k_enabled; then
     # [1] https://github.com/romkatv/powerlevel10k/blob/efc9ddd9b615a0042b5bcc36f97f070ca6fdf09e/README.md#homebrew
     source $(brew --prefix)/share/powerlevel10k/powerlevel10k.zsh-theme
 
-    # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
-    source ~/.p10k.zsh
+    # To customize prompt, run `p10k configure` or edit ~/.config/p10k.zsh.
+    source ~/.config/p10k.zsh
 
     # set ZSH_THEME to empty
     export ZSH_THEME=""


### PR DESCRIPTION
things that aren't needed in `~` are best organized in `~/.config` to avoid polluting `~`; also renaming `~/dotfiles` -> `~/.dotfiles`. will likely need to manually clean up old references after running cleanup command:

```shell
install-dotfiles.sh
...
rm ~/.alfred
rm ~/.rectangle.config.json
rm ~/.p10k.zsh
rm ~/dotfiles
```

will also need to update Alfred preferences sync folder. see `alfred/README.md`