### PR TITLE
`iterm2`: fix powerline glyphs in new iterm2, version 3.6.7

### DIFF
--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -25,7 +25,7 @@
 	<key>AiMaxTokens</key>
 	<integer>400000</integer>
 	<key>AiModel</key>
-	<string>gpt-5.1</string>
+	<string>gpt-5.2</string>
 	<key>AiResponseMaxTokens</key>
 	<integer>128000</integer>
 	<key>AitermURL</key>
@@ -314,7 +314,7 @@
 			<key>Disable Window Resizing</key>
 			<true/>
 			<key>Draw Powerline Glyphs</key>
-			<true/>
+			<false/>
 			<key>Flashing Bell</key>
 			<false/>
 			<key>Foreground Color</key>


### PR DESCRIPTION
the `AiModel` stuff was auto-added, decided to keep it in