### PR TITLE
`emacs`: remove "auto-added" section

### DIFF
--- a/emacs/init.el
+++ b/emacs/init.el
@@ -323,10 +323,3 @@
 ;; Enable visual line mode globally, which makes long lines wrap without "\"
 ;; at the end of the line.
 (global-visual-line-mode 1)
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Stuff that's automatically added/edited. Probs shouldn't manually edit this,
-;; other than explanatory comments.
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Added after first time I ran M-x list-timers
-(put 'list-timers 'disabled nil)


### PR DESCRIPTION
i had forgotten what this `list-timers` stuff was all about, so I commented it out & ran `M-x list-timers` again, & realized that this command is disabled. given the PR that we're stacked on is already removing most of the auto-added section, I reasoned it's fine to not re-enable this disabled command, so just deleting this section.