### PR TITLE
`cursor`: new keybinding

### DIFF
--- a/cursor/keybindings.jsonc
+++ b/cursor/keybindings.jsonc
@@ -64,5 +64,10 @@
     "key": "cmd+ctrl+[",
     "command": "editor.foldRecursively",
     "when": "editorTextFocus"
+  },
+  {
+    "key": "alt+cmd+s",
+    "command": "workbench.action.toggleUnifiedSidebarFromKeyboard",
+    "when": "cursor.agentIdeUnification.enabled == true && !isAuxiliaryWindowFocusedContext"
   }
 ]


### PR DESCRIPTION
this was automatically added in a new cursor version, seems only relevant when in agent mode