### PR TITLE
[WIP] `tmux`: support shift+enter in tmux

### DIFF
--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -360,6 +360,19 @@
 					<key>Version</key>
 					<integer>2</integer>
 				</dict>
+				<key>0xd-0x20000-0x24</key>
+				<dict>
+					<key>Action</key>
+					<integer>10</integer>
+					<key>Apply Mode</key>
+					<integer>1</integer>
+					<key>Escaping</key>
+					<integer>2</integer>
+					<key>Text</key>
+					<string>[13;2u</string>
+					<key>Version</key>
+					<integer>2</integer>
+				</dict>
 			</dict>
 			<key>Link Color</key>
 			<dict>

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -36,6 +36,11 @@
 # Configuration ################################################################
 ################################################################################
 
+# [WIP] attempting to get shift-enter to work
+set -g extended-keys on
+set -as terminal-features 'xterm*:extkeys'
+set -as terminal-features 'screen*:extkeys'
+
 # Use “screen-256color-bce” (no BCE) to force tmux to repaint column 0 on scroll
 # & avoid the green‐stripe background‑color-erase bug.
 # See: https://github.com/izzygomez/dotfiles/pull/2


### PR DESCRIPTION
this makes it so that shift+enter behaves as expected (new line) in claude code sessions as well