### PR TITLE
`zshrc_macos`: disable "slightly dim display on battery" in settings

### DIFF
--- a/zsh/fragments/zshrc_macos
+++ b/zsh/fragments/zshrc_macos
@@ -62,6 +62,10 @@ fi
 # macOS settings config
 ################################################################################
 
+# TODO: consider moving these settings to a separate file, e.g. `zshrc_macos_settings`,
+# that is only called once in a while. feels like an antipattern for us to check
+# all of these settings every time the shell is started.
+
 # Settings > Keyboard
 (
     # "Key repeat rate"
@@ -82,6 +86,12 @@ fi
         echo "zshrc_macos: updated InitialKeyRepeat to $desired_initial_key_repeat. Log out & back in, or restart, for this to take effect."
     fi
 )
+
+# Disable "Slightly dim display on battery" option found in Settings > Battery > Options
+if [[ "$(pmset -g custom 2>/dev/null | awk '/Battery Power/,0' | awk '/lessbright/{print $2}')" != "0" ]]; then
+    echo "zshrc_macos: disabling \"Slightly dim display on battery\". running sudo, so you'll need to enter your password..."
+    sudo pmset -b lessbright 0
+fi
 
 ################################################################################
 # Homebrew config & package configs


### PR DESCRIPTION
this is the start of a new section in `zshrc_macos` to configure OS settings that I would typically configure manually via the Settings app. it remains to be seen what can be done automatically via the command line, & also whether it's worth doing this at init time for `zsh`. will consider moving these over to a separate file that is called intermittently/manually after I add some more settings.